### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ CMD ./start.sh
 
 
 # docker build -t="mercurius" .
-# docker run --publish 4000:4000 -e REDISCLOUD_URL="redis://localhost:6379" mercurius
+# docker run --publish 4000:4000 -e REDISCLOUD_URL="redis://localhost:6379" -e GCM_API_KEY="" mercurius

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:latest
+
+# Install redis
+RUN apt-get update && apt-get install -y redis-server
+
+# Install Mercurius
+RUN mkdir /src
+WORKDIR /src
+ADD . /src
+RUN npm install
+RUN npm run build
+
+EXPOSE 4000
+
+RUN chmod +x start.sh
+CMD ./start.sh
+
+
+# docker build -t="mercurius" .
+# docker run --publish 4000:4000 -e REDISCLOUD_URL="redis://localhost:6379" mercurius

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,3 @@ EXPOSE 4000
 
 RUN chmod +x start.sh
 CMD ./start.sh
-
-
-# docker build -t="mercurius" .
-# docker run --publish 4000:4000 -e REDISCLOUD_URL="redis://localhost:6379" -e GCM_API_KEY="" mercurius

--- a/README.md
+++ b/README.md
@@ -46,5 +46,8 @@ host (`redis://localhost:6379`)
 ## DOCKER
 
 - clone this repo
-- cd mercurius && docker build -t="mercurius" .
-- docker run --publish 4000:4000 -e REDISCLOUD_URL="redis://localhost:6379" -e GCM_API_KEY="" mercurius
+
+```
+cd mercurius && docker build -t="mercurius" .
+docker run --publish 4000:4000 -e REDISCLOUD_URL="redis://localhost:6379" -e GCM_API_KEY="" mercurius
+```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Example:
 }
 ```
 
+## VARIABLES
+
+Mandatory :
+
+- REDISCLOUD_URL (Ex. redis://localhost:6379)
+
+Optional 
+- GCM_API_KEY : Your Google API Key to send notification to Chrome.
+- DISABLE_SSL_REDIRECT : Disable the built-in SSL redirection.
+
+
 ## INSTALL
 
 Install Redis database and set `REDISCLOUD_URL` environment variable to its 
@@ -49,5 +60,5 @@ host (`redis://localhost:6379`)
 
 ```
 cd mercurius && docker build -t="mercurius" .
-docker run --publish 4000:4000 -e REDISCLOUD_URL="redis://localhost:6379" -e GCM_API_KEY="" mercurius
+docker run --publish 4000:4000 -e REDISCLOUD_URL="redis://localhost:6379" -e GCM_API_KEY="" -e DISABLE_SSL_REDIRECT="1" mercurius
 ```

--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ Example:
 
 Install Redis database and set `REDISCLOUD_URL` environment variable to its 
 host (`redis://localhost:6379`)
+
+## DOCKER
+
+1/ clone this repo
+2/ cd mercurius && docker build -t="mercurius" .
+3/ docker run --publish 4000:4000 -e REDISCLOUD_URL="redis://localhost:6379" -e GCM_API_KEY="" mercurius

--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ host (`redis://localhost:6379`)
 
 ## DOCKER
 
-1/ clone this repo
-2/ cd mercurius && docker build -t="mercurius" .
-3/ docker run --publish 4000:4000 -e REDISCLOUD_URL="redis://localhost:6379" -e GCM_API_KEY="" mercurius
+- clone this repo
+- cd mercurius && docker build -t="mercurius" .
+- docker run --publish 4000:4000 -e REDISCLOUD_URL="redis://localhost:6379" -e GCM_API_KEY="" mercurius

--- a/index.js
+++ b/index.js
@@ -16,15 +16,6 @@ app.use(bodyParser.json());
 
 app.use(function(req, res, next) {
   var host = req.get('Host');
-
-  if (host.indexOf('localhost') !== 0 && host.indexOf('127.0.0.1') !== 0) {
-    // https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security
-    res.header('Strict-Transport-Security', 'max-age=15768000');
-    // https://github.com/rangle/force-ssl-heroku/blob/master/force-ssl-heroku.js
-    if (req.headers['x-forwarded-proto'] !== 'https') {
-      return res.redirect('https://' + host + req.url);
-    }
-  }
   return next();
 });
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,16 @@ app.use(bodyParser.json());
 
 app.use(function(req, res, next) {
   var host = req.get('Host');
+
+  if (!process.env.no_ssl_redirect && host.indexOf('localhost') !== 0 && host.indexOf('127.0.0.1') !== 0) {
+    // https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security
+    res.header('Strict-Transport-Security', 'max-age=15768000');
+    // https://github.com/rangle/force-ssl-heroku/blob/master/force-ssl-heroku.js
+    if (req.headers['x-forwarded-proto'] !== 'https') {
+      return res.redirect('https://' + host + req.url);
+    }
+  }
+
   return next();
 });
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ app.use(bodyParser.json());
 app.use(function(req, res, next) {
   var host = req.get('Host');
 
-  if (!process.env.no_ssl_redirect && host.indexOf('localhost') !== 0 && host.indexOf('127.0.0.1') !== 0) {
+  if (!process.env.DISABLE_SSL_REDIRECT && host.indexOf('localhost') !== 0 && host.indexOf('127.0.0.1') !== 0) {
     // https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security
     res.header('Strict-Transport-Security', 'max-age=15768000');
     // https://github.com/rangle/force-ssl-heroku/blob/master/force-ssl-heroku.js

--- a/redis.js
+++ b/redis.js
@@ -1,6 +1,6 @@
 var redis = require('redis');
 
-var client = redis.createClient(process.env.REDISCLOUD_URL, {no_ready_check: true});
+//var client = redis.createClient(process.env.REDISCLOUD_URL, {no_ready_check: true});
 
 commands = {};
 

--- a/redis.js
+++ b/redis.js
@@ -1,6 +1,6 @@
 var redis = require('redis');
 
-//var client = redis.createClient(process.env.REDISCLOUD_URL, {no_ready_check: true});
+var client = redis.createClient(process.env.REDISCLOUD_URL, {no_ready_check: true});
 
 commands = {};
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+nohup redis-server &
+npm start


### PR DESCRIPTION
Hi,

I made some modifications to be able to host Mercurius on my own private server and I thought it might be useful for other users.
## Change
- Add Dockerfile. (Contain Mercurius and the mandatory Redis-server)
- Add start.sh (startup script for the Docker image).
- Add a way to disable the SSL redirection. In my case the Docker container is not listening on the localhost it cause nasty redirection behind the my Nginx setup. The best way i have found is to add a « flag » to avoid the redirection.
- Update README
